### PR TITLE
Implement Multi-Flag Filtering Feature

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -203,21 +203,26 @@ edit 69 n/ TAN LESHEW p/ 77337733 e/ mrtan@ntu.sg a/ COM3 j/ doctor i/ 100000000
 This feature allows users to search for customers by specific details such as name, address, email, phone number, job title, or remarks. 
 
 **How to Use It:**  
-To perform a search, use the `filter` command followed by a flag (indicating the field you want to search) and the corresponding search term. Searches are **case-insensitive** and use **substring-matching**. See [substring-matching](#substring-matching) to learn more. 
+To perform a search, use the `filter` command followed by one or more flags (indicating the fields to search) and the corresponding search terms. 
+ Searches are **case-insensitive** and use [**substring-matching**](#substring-matching).
 
 - **Command Format:** 
-```
-filter <FLAG>/ <SEARCH TERM>
-```
+  ```
+  filter <FLAG>/ <SEARCH TERM> [<ADDITIONAL_FLAGS>/ <SEARCH TERM>]
+  ```
 - **Examples:** 
   - Filter customers by name: 
-  ```
-  filter n/ TAN LESHEW
-  ```
+    ```
+    filter n/ TAN LESHEW
+    ```
   - Filter customers by job:
-  ```
-  e.g. filter j/ doctor
-  ```
+    ```
+    filter j/ doctor
+    ```
+  - Filter customers by name, job and remark:
+    ```
+    filter n/ Gordon Moore j/ doctor r/ award winner
+    ```
 
 #### Parameters
 | Parameter   | Expected Format                                                                                              | Explanation                                                                                             |
@@ -235,30 +240,27 @@ filter <FLAG>/ <SEARCH TERM>
 
 #### Substring Matching:
 - Substring matching is used for searches, meaning that the search term must match a part of the field in the same order as it appears in the customer record.
-- For instance, if a customer’s name is "John Lee", the search term "John", "Lee", or "John Lee" will match, but "Lee John" will not.
-
+- For instance, if a customer’s name is `Gordon Moore`, the search term `Gordon`, `Moore`, or `Gordon Moore` will match, but `Moore Gordon` will not.
 
 #### What to Expect
 - **If Successful:**
   - Message: "Here are all the customers that match your search: (List of customers)."
 - **If Unsuccessful (No Matches Found):**
   - Message: "No customers match your search criteria."
-- **If Multiple Filters Are Used:**
-  - Message: "Using multiple filters is not supported yet. Please use only one filter."
 - **If There is an Error:** 
   - No Valid Flags Used:
     - Message:
     
-      "filter: Searches for all customers whose specified field contains the given
-    substring (case-insensitive) and displays the results in a numbered list.
+      "filter: Searches for all customers whose specified field contains the given substring (case-insensitive) and displays the results in a numbered list.
     
       Parameters: `<FLAG>/ <SEARCH TERM>`
       
       Flags: `n/` (name), `p/` (phone), `e/` (email), `a/` (address), `j/` (job), `r/` (remarks)
       
-      Example: `filter n/ Alice`
-    
-      This will find all customers whose names contain 'Alice'."
+      Example: `filter n/ Alice p/ 91112222`
+
+      This will find all customers whose names contain 'Alice' and has phone number '91112222'."
+
   - If Search Term Fails to Meet Requirement (i.e. Phone Number longer than 8 digits):
     - The system will display usage hints specific to the first invalid search term.
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -22,7 +22,7 @@ public class FilterCommand extends Command {
             + "Parameters: <FLAG>/ <SEARCH TERM>\n"
             + "Flags: n/ (name), p/ (phone), e/ (email), a/ (address), j/ (job), r/ (remarks)\n"
             + "Example: " + COMMAND_WORD + " n/ Alice" + " p/ 91112222\n"
-            + "This will find all customers whose names contain 'Alice' and has phone number '91112222'.";
+            + "This will find all customers whose names contain 'Alice' and whose phone number is '91112222'.";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -21,8 +21,8 @@ public class FilterCommand extends Command {
             + "contains the given substring (case-insensitive) and displays the results in a numbered list.\n"
             + "Parameters: <FLAG>/ <SEARCH TERM>\n"
             + "Flags: n/ (name), p/ (phone), e/ (email), a/ (address), j/ (job), r/ (remarks)\n"
-            + "Example: " + COMMAND_WORD + " n/ Alice\n"
-            + "This will find all customers whose names contain 'Alice'.";
+            + "Example: " + COMMAND_WORD + " n/ Alice" + " p/ 91112222\n"
+            + "This will find all customers whose names contain 'Alice' and has phone number '91112222'.";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -20,10 +20,7 @@ public class FilterCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose field contains the "
             + "the specified substring (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: <FLAG> <SUBSTRING>\n"
-            + "Example: " + COMMAND_WORD + " n/ Alice";
-
-    public static final String MULTIPLE_FILTERS_NOT_IMPLEMENTED = "Using multiple filters is not supported yet. "
-            + "Please use only one filter.";
+            + "Example: " + COMMAND_WORD + " n/ Alice" + " p/ 91112222";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -11,11 +11,17 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.AddressContainsSubstringPredicate;
+import seedu.address.model.person.predicates.CombinedPredicate;
 import seedu.address.model.person.predicates.EmailContainsSubstringPredicate;
 import seedu.address.model.person.predicates.JobContainsSubstringPredicate;
 import seedu.address.model.person.predicates.NameContainsSubstringPredicate;
@@ -41,38 +47,19 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_INCOME, PREFIX_JOB, PREFIX_REMARK, PREFIX_TAG);
 
-        // Filtering by multiple fields/flags has not been implemented yet
+        // Throw an error if no filters are used
         long numberOfFiltersUsed = countPrefixesUsed(argMultimap, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                 PREFIX_ADDRESS, PREFIX_JOB, PREFIX_INCOME, PREFIX_REMARK, PREFIX_TAG);
-        if (numberOfFiltersUsed > 1) {
-            throw new ParseException(FilterCommand.MULTIPLE_FILTERS_NOT_IMPLEMENTED);
+
+        if (numberOfFiltersUsed == 0) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
         }
 
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            String substring = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()).fullName;
-            return new FilterCommand(new NameContainsSubstringPredicate(substring));
-        }
-        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            String substring = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()).value;
-            return new FilterCommand(new PhoneContainsSubstringPredicate(substring));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            String substring = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()).value;
-            return new FilterCommand(new EmailContainsSubstringPredicate(substring));
-        }
-        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            String substring = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()).value;
-            return new FilterCommand(new AddressContainsSubstringPredicate(substring));
-        }
-        if (argMultimap.getValue(PREFIX_JOB).isPresent()) {
-            String substring = ParserUtil.parseJob(argMultimap.getValue(PREFIX_JOB).get()).value;
-            return new FilterCommand(new JobContainsSubstringPredicate(substring));
-        }
-        if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
-            String substring = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()).value;
-            return new FilterCommand(new RemarkContainsSubstringPredicate(substring));
-        }
-        throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        // Handle flags and search terms
+        List<Predicate<Person>> predicates = collectPredicates(argMultimap);
+        Predicate<Person> combinedPredicate = combinePredicates(predicates);
+
+        return new FilterCommand(combinedPredicate);
     }
 
     /**
@@ -86,5 +73,64 @@ public class FilterCommandParser implements Parser<FilterCommand> {
         return Arrays.stream(prefixes)
                 .filter(prefix -> argMultimap.getValue(prefix).isPresent())
                 .count();
+    }
+
+    /**
+     * Collects the list of predicates based on the provided argument map.
+     *
+     * @param argMultimap The argument multimap containing the parsed arguments.
+     * @return A list of predicates corresponding to the filters provided.
+     * @throws ParseException if there are any parsing issues.
+     */
+    private List<Predicate<Person>> collectPredicates(ArgumentMultimap argMultimap) throws ParseException {
+        // Collect individual predicates to be combined with AND operator later.
+        // This "collection then combine" approach enhances testability by avoiding the use of anonymous
+        // lambda predicates which ensures that the combined predicate can be easily tested and debugged.
+
+        List<Predicate<Person>> predicates = new ArrayList<>();
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String substring = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()).fullName;
+            predicates.add(new NameContainsSubstringPredicate(substring));
+        }
+        if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            String substring = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get()).value;
+            predicates.add(new PhoneContainsSubstringPredicate(substring));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            String substring = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()).value;
+            predicates.add(new EmailContainsSubstringPredicate(substring));
+        }
+        if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            String substring = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()).value;
+            predicates.add(new AddressContainsSubstringPredicate(substring));
+        }
+        if (argMultimap.getValue(PREFIX_JOB).isPresent()) {
+            String substring = ParserUtil.parseJob(argMultimap.getValue(PREFIX_JOB).get()).value;
+            predicates.add(new JobContainsSubstringPredicate(substring));
+        }
+        if (argMultimap.getValue(PREFIX_REMARK).isPresent()) {
+            String substring = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()).value;
+            predicates.add(new RemarkContainsSubstringPredicate(substring));
+        }
+
+        return predicates;
+    }
+
+    /**
+     * Combines the given list of predicates into a single predicate using the AND operator.
+     * The combined predicate returns {@code true} only if all predicates return {@code true}.
+     *
+     * @param predicates The list of predicates to combine. Must not be null or empty.
+     * @return A combined predicate that represents the logical AND of all provided predicates.
+     * @throws IllegalArgumentException if the list of predicates is empty.
+     */
+    private Predicate<Person> combinePredicates(List<Predicate<Person>> predicates) {
+        Objects.requireNonNull(predicates, "Predicates list must not be null");
+        if (predicates.isEmpty()) {
+            throw new IllegalArgumentException("Predicates list must not be empty");
+        }
+
+        return new CombinedPredicate(predicates);
     }
 }

--- a/src/main/java/seedu/address/model/person/predicates/CombinedPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/CombinedPredicate.java
@@ -1,0 +1,75 @@
+package seedu.address.model.person.predicates;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import seedu.address.model.person.Person;
+
+/**
+ * Represents a predicate that combines multiple other predicates using the AND operator.
+ * This class allows you to test multiple conditions on a {@link Person} object in a way that
+ * ensures all provided predicates must evaluate to true for the overall predicate to return true.
+ *
+ * <p>This is particularly useful for filtering when you need to apply multiple conditions
+ * simultaneously, such as filtering by name, phone number, email, etc.</p>
+ */
+public class CombinedPredicate implements Predicate<Person> {
+    private final List<Predicate<Person>> predicates;
+
+    /**
+     * Constructs a {@code CombinedPredicate} with a list of predicates.
+     * Each predicate in the list must evaluate to {@code true} for this combined predicate
+     * to return {@code true} when tested.
+     *
+     * @param predicates the list of predicates to combine
+     */
+    public CombinedPredicate(List<Predicate<Person>> predicates) {
+        this.predicates = Objects.requireNonNull(predicates, "Predicates list must not be null");
+    }
+
+    /**
+     * Tests the given {@code Person} object against all the combined predicates.
+     * This method returns {@code true} if all predicates return {@code true} for the given person.
+     *
+     * @param person the {@code Person} to be tested
+     * @return {@code true} if all predicates return {@code true}; {@code false} otherwise
+     */
+    @Override
+    public boolean test(Person person) {
+        for (Predicate<Person> predicate : predicates) {
+            if (!predicate.test(person)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks whether this combined predicate is equal to another object.
+     * Two {@code CombinedPredicate} objects are considered equal if their underlying
+     * list of predicates are equal. This method is used for ease of testing without dealing with lambdas.
+     *
+     * @param other the object to compare to
+     * @return {@code true} if this combined predicate is equal to the other object; {@code false} otherwise
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof CombinedPredicate)) {
+            return false;
+        }
+
+        CombinedPredicate that = (CombinedPredicate) other;
+        return this.predicates.equals(that.predicates);
+    }
+
+    // This method is used for ease of testing without dealing with lambdas.
+    @Override
+    public int hashCode() {
+        return predicates.hashCode();
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,6 +8,10 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_REMARK_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
@@ -23,10 +27,12 @@ import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Remark;
+import seedu.address.model.person.predicates.CombinedPredicate;
 import seedu.address.model.person.predicates.NameContainsSubstringPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
+
 
 public class AddressBookParserTest {
 
@@ -70,12 +76,18 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_filter() throws Exception {
         String substring = "foo";
-        System.out.println(FilterCommand.COMMAND_WORD + " "
-                + CliSyntax.PREFIX_NAME.getPrefix() + " " + substring);
-        FilterCommand command = (FilterCommand) parser.parseCommand(
-                FilterCommand.COMMAND_WORD + " "
-                        + CliSyntax.PREFIX_NAME.getPrefix() + " " + substring);
-        assertEquals(new FilterCommand(new NameContainsSubstringPredicate(substring)), command);
+
+        // Build expected command
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new NameContainsSubstringPredicate(substring));
+        CombinedPredicate combinedPredicate = new CombinedPredicate(expectedPredicates);
+        FilterCommand expectedCommand = new FilterCommand(combinedPredicate);
+
+        // Build actual command
+        FilterCommand actualCommand = (FilterCommand) parser.parseCommand(FilterCommand.COMMAND_WORD
+                + " " + CliSyntax.PREFIX_NAME.getPrefix() + " " + substring);
+
+        assertEquals(expectedCommand, actualCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -4,10 +4,16 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.AddressContainsSubstringPredicate;
+import seedu.address.model.person.predicates.CombinedPredicate;
 import seedu.address.model.person.predicates.EmailContainsSubstringPredicate;
 import seedu.address.model.person.predicates.JobContainsSubstringPredicate;
 import seedu.address.model.person.predicates.NameContainsSubstringPredicate;
@@ -20,60 +26,98 @@ public class FilterCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_validArgs_returnsFilterCommand() {
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new NameContainsSubstringPredicate("Alice"));
-        assertParseSuccess(parser, " n/ Alice", expectedFilterCommand);
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new NameContainsSubstringPredicate("Alice"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
 
-        // multiple whitespaces between flag and substring
-        assertParseSuccess(parser, " n/ \n  Alice \t", expectedFilterCommand);
+        assertParseSuccess(parser, " n/ Alice", expectedFilterCommand);
     }
 
     @Test
     public void parse_addressFlag_returnsAddressFilterCommand() {
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new AddressContainsSubstringPredicate("Block 123"));
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new AddressContainsSubstringPredicate("Block 123"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
         assertParseSuccess(parser, " a/ Block 123", expectedFilterCommand);
     }
 
     @Test
     public void parse_emailFlag_returnsEmailFilterCommand() {
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new EmailContainsSubstringPredicate("alice@hello.com"));
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new EmailContainsSubstringPredicate("alice@hello.com"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
         assertParseSuccess(parser, " e/ alice@hello.com", expectedFilterCommand);
     }
 
     @Test
     public void parse_jobFlag_returnsRemarkFilterCommand() {
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new JobContainsSubstringPredicate("Software Engineer"));
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new JobContainsSubstringPredicate("Software Engineer"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
         assertParseSuccess(parser, " j/ Software Engineer", expectedFilterCommand);
     }
 
     @Test
     public void parse_nameFlag_returnsNameFilterCommand() {
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new NameContainsSubstringPredicate("Alice"));
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new NameContainsSubstringPredicate("Alice"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
         assertParseSuccess(parser, " n/ Alice", expectedFilterCommand);
     }
 
-
     @Test
     public void parse_phoneFlag_returnsPhoneFilterCommand() {
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new PhoneContainsSubstringPredicate("91112222"));
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new PhoneContainsSubstringPredicate("91112222"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
         assertParseSuccess(parser, " p/ 91112222", expectedFilterCommand);
     }
 
 
     @Test
     public void parse_remarkFlag_returnsRemarkFilterCommand() {
-        FilterCommand expectedFilterCommand =
-                new FilterCommand(new RemarkContainsSubstringPredicate("is a celebrity"));
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new RemarkContainsSubstringPredicate("is a celebrity"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
         assertParseSuccess(parser, " r/ is a celebrity", expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_validMultipleArgs_returnsFilterCommand() {
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new NameContainsSubstringPredicate("Alice"));
+        expectedPredicates.add(new PhoneContainsSubstringPredicate("91112222"));
+        expectedPredicates.add(new EmailContainsSubstringPredicate("alice@example.com"));
+        expectedPredicates.add(new AddressContainsSubstringPredicate("Block 123"));
+        expectedPredicates.add(new JobContainsSubstringPredicate("Software Engineer"));
+        expectedPredicates.add(new RemarkContainsSubstringPredicate("is a celebrity"));
+
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
+        assertParseSuccess(parser, " n/ Alice p/ 91112222 e/ alice@example.com a/ Block 123 "
+                + "j/ Software Engineer r/ is a celebrity", expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_validMultipleArgsWithWhitespace_returnsFilterCommand() {
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new NameContainsSubstringPredicate("Alice"));
+        expectedPredicates.add(new PhoneContainsSubstringPredicate("91112222"));
+
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
+        assertParseSuccess(parser, " n/  \t Alice \n p/  \t 91112222 ", expectedFilterCommand);
     }
 }


### PR DESCRIPTION
This update introduces multi-flag filtering, allowing users to filter using multiple fields in a single command.

Changes include:
- Introduction of`CombinedPredicate` class: This is to facilitate combining multiple predicates. This approach was necessary because using the Predicate<Person> superclass directly caused testing challenges due to lambdas being instantiated in memory, making them difficult to compare.
- Enhancement of filter parsing logic to use `CombinedPredicate` class.
- Test updates
  - Existing filter parsing tests were updated to support new parsing logic with `CombinedPredicate`.
  - New tests were added to cover multi-flag filter parsing.
- Update to `FilterCommand` usage message to reflect multi-flag filtering.
- Update UG documentation to reflect multi-flag filtering functionality.

Closes #65 and #66.