### PR TITLE
Implement Filtering of Customers by Tier

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -266,7 +266,7 @@ This feature allows users to search for customers by specific details such as na
 
 **How to Use It:**  
 To perform a search, use the `filter` command followed by one or more flags (indicating the fields to search) and the corresponding search terms. 
- Searches are **case-insensitive** and use [**substring-matching**](#substring-matching).
+ Searches are **case-insensitive** and use [**substring-matching**](#substring-matching), **except for Tier**, which must start with the specified substring.
 
 - **Command Format:** 
   ```
@@ -300,6 +300,7 @@ To perform a search, use the `filter` command followed by one or more flags (ind
 - `a/` for Address
 - `j/` for Job
 - `r/` for Remarks
+- `t/` for Tier
 
 #### Substring Matching:
 - Substring matching is used for searches, meaning that the search term must match a part of the field in the same order as it appears in the customer record.
@@ -307,9 +308,9 @@ To perform a search, use the `filter` command followed by one or more flags (ind
 
 #### What to Expect
 - **If Successful:**
-  - Message: "Here are all the customers that match your search: (List of customers)."
+  - Message: "`x` person listed!", where `x` is the number of matching results.
 - **If Unsuccessful (No Matches Found):**
-  - Message: "No customers match your search criteria."
+  - Message: "0 persons listed!"
 - **If There is an Error:** 
   - No Valid Flags Used:
     - Message:
@@ -324,7 +325,7 @@ To perform a search, use the `filter` command followed by one or more flags (ind
 
       This will find all customers whose names contain 'Alice' and has phone number '91112222'."
 
-  - If Search Term Fails to Meet Requirement (i.e. Phone Number longer than 8 digits):
+  - Search Term Fails to Meet Requirement (i.e. Phone Number longer than 8 digits):
     - The system will display usage hints specific to the first invalid search term.
 
 ---

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -15,14 +15,15 @@ public class StringUtil {
      * Returns true if the {@code sentence} contains the {@code substring}.
      *   Ignores case, does not require full word match.
      *   <br>examples:<pre>
-     *       containsWordIgnoreCase("ABc def", "abc") == true
-     *       containsWordIgnoreCase("ABc def", "DEF") == true
-     *       containsWordIgnoreCase("ABc def", "AB") == true
-     *       containsWordIgnoreCase("ABc def", "cde") == false // Sentence does not contain substring.
-     *       containsWordIgnoreCase("ABc def", "c de") == true
+     *       containsSubstringIgnoreCase("ABc def", "abc") == true
+     *       containsSubstringIgnoreCase("ABc def", "DEF") == true
+     *       containsSubstringIgnoreCase("ABc def", "AB") == true
+     *       containsSubstringIgnoreCase("ABc def", "cde") == false // Sentence does not contain substring.
+     *       containsSubstringIgnoreCase("ABc def", "c de") == true
      *       </pre>
      * @param sentence cannot be null
      * @param substring cannot be null, cannot be empty
+     * @return true if the {@code sentence} contains the {@code substring}, ignoring case
      */
     public static boolean containsSubstringIgnoreCase(String sentence, String substring) {
         requireNonNull(sentence);
@@ -36,6 +37,35 @@ public class StringUtil {
         String upperCaseSubstring = preppedSubstring.toUpperCase();
 
         return upperCaseSentence.contains(upperCaseSubstring);
+    }
+
+    /**
+     * Returns true if the {@code sentence} starts with {@code substring}
+     *   Ignores case, does not require full word match.
+     *   <br>examples:<pre>
+     *       startsWithSubstringIgnoreCase("ABc def", "abc") == true
+     *       startsWithSubstringIgnoreCase("ABc def", "DEF") == false // "DEF" is not at the start.
+     *       startsWithSubstringIgnoreCase("ABc def", "AB") == true
+     *       startsWithSubstringIgnoreCase("ABc def", "cde") == false // "cde" is not at the start.
+     *       startsWithSubstringIgnoreCase("ABc def", "ABc d") == true
+     *       startsWithSubstringIgnoreCase("ABc def", "bc") == false // "bc" is not at the start.
+     *       </pre>
+     * @param sentence cannot be null
+     * @param substring cannot be null, cannot be empty
+     * @return true if the {@code sentence} starts with the {@code substring}, ignoring case
+     */
+    public static boolean startsWithSubstringIgnoreCase(String sentence, String substring) {
+        requireNonNull(sentence);
+        requireNonNull(substring);
+
+        String preppedSubstring = substring.trim();
+        checkArgument(!preppedSubstring.isEmpty(), "Substring parameter cannot be empty");
+
+        // Convert both sentence and substring to upper case to ignore case
+        String upperCaseSentence = sentence.toUpperCase();
+        String upperCaseSubstring = preppedSubstring.toUpperCase();
+
+        return upperCaseSentence.startsWith(upperCaseSubstring);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -27,6 +27,7 @@ import seedu.address.model.person.predicates.JobContainsSubstringPredicate;
 import seedu.address.model.person.predicates.NameContainsSubstringPredicate;
 import seedu.address.model.person.predicates.PhoneContainsSubstringPredicate;
 import seedu.address.model.person.predicates.RemarkContainsSubstringPredicate;
+import seedu.address.model.person.predicates.TierStartsWithSubstringPredicate;
 
 /**
  * Parses input arguments and creates a new FilterCommand object
@@ -113,7 +114,10 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             String substring = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get()).value;
             predicates.add(new RemarkContainsSubstringPredicate(substring));
         }
-
+        if (argMultimap.getValue(PREFIX_TIER).isPresent()) {
+            String substring = ParserUtil.parseTier(argMultimap.getValue(PREFIX_TIER).get()).tagName.name();
+            predicates.add(new TierStartsWithSubstringPredicate(substring));
+        }
         return predicates;
     }
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -115,7 +115,7 @@ public class FilterCommandParser implements Parser<FilterCommand> {
             predicates.add(new RemarkContainsSubstringPredicate(substring));
         }
         if (argMultimap.getValue(PREFIX_TIER).isPresent()) {
-            String substring = ParserUtil.parseTier(argMultimap.getValue(PREFIX_TIER).get()).tagName.name();
+            String substring = argMultimap.getValue(PREFIX_TIER).get();
             predicates.add(new TierStartsWithSubstringPredicate(substring));
         }
         return predicates;

--- a/src/main/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.person.predicates;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s assigned {@code Tier} starts with a specified String.
+ */
+public class TierStartsWithSubstringPredicate implements Predicate<Person> {
+    protected final String substring;
+
+    public TierStartsWithSubstringPredicate(String substring) {
+        this.substring = substring;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return StringUtil.startsWithSubstringIgnoreCase(person.getTier().tagName.name(), substring);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TierStartsWithSubstringPredicate)) {
+            return false;
+        }
+
+        TierStartsWithSubstringPredicate otherNameContainsSubstringPredicate = (TierStartsWithSubstringPredicate) other;
+        return substring.equals(otherNameContainsSubstringPredicate.substring);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("substring", substring.toUpperCase()).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicate.java
@@ -1,10 +1,10 @@
 package seedu.address.model.person.predicates;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
-
-import java.util.function.Predicate;
 
 /**
  * Tests that a {@code Person}'s assigned {@code Tier} starts with a specified String.

--- a/src/main/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicate.java
@@ -13,7 +13,7 @@ public class TierStartsWithSubstringPredicate implements Predicate<Person> {
     protected final String substring;
 
     public TierStartsWithSubstringPredicate(String substring) {
-        this.substring = substring;
+        this.substring = substring.toUpperCase();
     }
 
     @Override
@@ -38,6 +38,6 @@ public class TierStartsWithSubstringPredicate implements Predicate<Person> {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("substring", substring.toUpperCase()).toString();
+        return new ToStringBuilder(this).add("substring", substring).toString();
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -19,6 +19,7 @@ import seedu.address.model.person.predicates.JobContainsSubstringPredicate;
 import seedu.address.model.person.predicates.NameContainsSubstringPredicate;
 import seedu.address.model.person.predicates.PhoneContainsSubstringPredicate;
 import seedu.address.model.person.predicates.RemarkContainsSubstringPredicate;
+import seedu.address.model.person.predicates.TierStartsWithSubstringPredicate;
 
 public class FilterCommandParserTest {
 
@@ -95,6 +96,15 @@ public class FilterCommandParserTest {
     }
 
     @Test
+    public void parse_tierFlag_returnsRemarkFilterCommand() {
+        List<Predicate<Person>> expectedPredicates = new ArrayList<>();
+        expectedPredicates.add(new TierStartsWithSubstringPredicate("gOLD"));
+        FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
+
+        assertParseSuccess(parser, " t/ GOLD", expectedFilterCommand);
+    }
+
+    @Test
     public void parse_validMultipleArgs_returnsFilterCommand() {
         List<Predicate<Person>> expectedPredicates = new ArrayList<>();
         expectedPredicates.add(new NameContainsSubstringPredicate("Alice"));
@@ -103,11 +113,12 @@ public class FilterCommandParserTest {
         expectedPredicates.add(new AddressContainsSubstringPredicate("Block 123"));
         expectedPredicates.add(new JobContainsSubstringPredicate("Software Engineer"));
         expectedPredicates.add(new RemarkContainsSubstringPredicate("is a celebrity"));
+        expectedPredicates.add(new TierStartsWithSubstringPredicate("GOLD"));
 
         FilterCommand expectedFilterCommand = new FilterCommand(new CombinedPredicate(expectedPredicates));
 
         assertParseSuccess(parser, " n/ Alice p/ 91112222 e/ alice@example.com a/ Block 123 "
-                + "j/ Software Engineer r/ is a celebrity", expectedFilterCommand);
+                + "j/ Software Engineer r/ is a celebrity t/ gold", expectedFilterCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicateTest.java
@@ -1,12 +1,13 @@
 package seedu.address.model.person.predicates;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import seedu.address.testutil.PersonBuilder;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
 
 public class TierStartsWithSubstringPredicateTest {
 

--- a/src/test/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/predicates/TierStartsWithSubstringPredicateTest.java
@@ -1,0 +1,109 @@
+package seedu.address.model.person.predicates;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import seedu.address.testutil.PersonBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TierStartsWithSubstringPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateSubstring = "first";
+        String secondPredicateSubstring = "first second";
+
+        TierStartsWithSubstringPredicate firstPredicate =
+                new TierStartsWithSubstringPredicate(firstPredicateSubstring);
+        TierStartsWithSubstringPredicate secondPredicate =
+                new TierStartsWithSubstringPredicate(secondPredicateSubstring);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        TierStartsWithSubstringPredicate firstPredicateCopy =
+                new TierStartsWithSubstringPredicate(firstPredicateSubstring);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tierStartsWithSubstring_returnsTrue() {
+        // Full tier match
+        TierStartsWithSubstringPredicate predicate = new TierStartsWithSubstringPredicate("gold");
+        assertTrue(predicate.test(new PersonBuilder().withTier("gold").build()));
+
+        // Partial tier match
+        predicate = new TierStartsWithSubstringPredicate("go");
+        assertTrue(predicate.test(new PersonBuilder().withTier("gold").build()));
+
+        // Mixed-case substring
+        predicate = new TierStartsWithSubstringPredicate("gOlD");
+        assertTrue(predicate.test(new PersonBuilder().withTier("GOLD").build()));
+    }
+
+    @Test
+    public void test_emptySubstring_throwsException() {
+        TierStartsWithSubstringPredicate predicate = new TierStartsWithSubstringPredicate("");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> predicate.test(
+                new PersonBuilder().withTier("GOLD").build()));
+    }
+
+    @Test
+    public void test_tierDoesNotStartWithSubstring_returnsFalse() {
+        // Non-matching substring
+        TierStartsWithSubstringPredicate predicate = new TierStartsWithSubstringPredicate("gold");
+        assertFalse(predicate.test(new PersonBuilder().withTier("silver").build()));
+
+        // Substring matches name but does not match tier
+        predicate = new TierStartsWithSubstringPredicate("Alice");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("91234567")
+                .withEmail("alice@email.com").withAddress("Main Street").withRemark("Genius")
+                .withJob("Doctor").withTier("GOLD").build()));
+
+        // Substring matches phone but does not match tier
+        predicate = new TierStartsWithSubstringPredicate("91234567");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("91234567")
+                .withEmail("alice@email.com").withAddress("Main Street").withRemark("Genius")
+                .withJob("Doctor").build()));
+
+        // Substring matches email but does not match tier
+        predicate = new TierStartsWithSubstringPredicate("alice@email.com");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("91234567")
+                .withEmail("alice@email.com").withAddress("Main Street").withRemark("Genius")
+                .withJob("Doctor").withTier("GOLD").build()));
+
+        // Substring matches address but does not match tier
+        predicate = new TierStartsWithSubstringPredicate("Main Street");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("91234567")
+                .withEmail("alice@email.com").withAddress("Main Street").withRemark("Genius")
+                .withJob("Doctor").withTier("GOLD").build()));
+
+        // Substring matches remark but does not match tier
+        predicate = new TierStartsWithSubstringPredicate("Doctor");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("91234567")
+                .withEmail("alice@email.com").withAddress("Main Street").withRemark("Genius")
+                .withJob("Doctor").withTier("GOLD").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        String substring = "testing substring";
+        TierStartsWithSubstringPredicate predicate = new TierStartsWithSubstringPredicate(substring);
+
+        String expected = TierStartsWithSubstringPredicate.class.getCanonicalName()
+                + "{substring=" + substring.toUpperCase() + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}


### PR DESCRIPTION
Users can now filter customers by using the Tier flag. The filtering works by matching the the user input as a prefix to the available Tiers.

Changes:
- Added Tier filtering: Tier filtering works by checking that the person's Tier starts with the user input for the search term.
- Tests:
   - Added unit tests for TierStartsWithPredicate.
   - Added tests for parsing of Tier flag/search term for filter command. 
**Note that the user input for the search term for Tier is not validated against the Tier class**, as the parsing of Tier requires exact matches to the enum.
- Documentation: Updated UG for Filter Command to include Tier. **Please verify that the 1 liner to explain that Tier requires prefix-matching is sufficent!**

Closes #70