### PR TITLE
Change equality clause in Person.java

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -18,19 +18,13 @@ public class Person {
     private final Name name;
     private final Phone phone;
     private final Email email;
-    private final Address address;
-
-    private final Job job;
 
     // Data fields
-
+    private final Address address;
+    private final Job job;
     private final Income income;
-
     private final Tier tier;
-
     private final Remark remark;
-
-    private final Status status;
 
     /**
      * Every field must be present and not null.
@@ -80,10 +74,6 @@ public class Person {
 
     public Remark getRemark() {
         return remark;
-    }
-
-    public Status getStatus() {
-        return status;
     }
 
     /**
@@ -137,7 +127,6 @@ public class Person {
                 .add("income", income)
                 .add("tier", tier)
                 .add("remark", remark)
-                .add("status", status)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.status.Status;
 import seedu.address.model.tier.Tier;
 
 /**
@@ -17,17 +18,19 @@ public class Person {
     private final Name name;
     private final Phone phone;
     private final Email email;
-
-    // Data fields
     private final Address address;
 
     private final Job job;
+
+    // Data fields
 
     private final Income income;
 
     private final Tier tier;
 
     private final Remark remark;
+
+    private final Status status;
 
     /**
      * Every field must be present and not null.
@@ -79,6 +82,10 @@ public class Person {
         return remark;
     }
 
+    public Status getStatus() {
+        return status;
+    }
+
     /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
@@ -110,11 +117,7 @@ public class Person {
         }
 
         Person otherPerson = (Person) other;
-        return name.equals(otherPerson.name)
-                && phone.equals(otherPerson.phone)
-                && email.equals(otherPerson.email)
-                && address.equals(otherPerson.address)
-                && job.equals(otherPerson.job);
+        return isSamePerson(otherPerson);
     }
 
     @Override
@@ -134,6 +137,7 @@ public class Person {
                 .add("income", income)
                 .add("tier", tier)
                 .add("remark", remark)
+                .add("status", status)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/status/Status.java
+++ b/src/main/java/seedu/address/model/status/Status.java
@@ -1,0 +1,2 @@
+package seedu.address.model.status;public class Status {
+}

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -84,7 +84,7 @@ public class PersonTest {
 
         // different job -> returns false
         editedAlice = new PersonBuilder(ALICE).withJob(VALID_JOB_BOB).build();
-        assertFalse(ALICE.equals(editedAlice));
+        assertTrue(ALICE.equals(editedAlice));
 
         // different tier -> returns true
         editedAlice = new PersonBuilder(ALICE).withTier("Silver").build();

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -78,11 +78,11 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build();
         assertNotEquals(ALICE, editedAlice);
 
-        // different address -> returns false
+        // different address -> returns true
         editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
-        assertNotEquals(ALICE, editedAlice);
+        assertTrue(ALICE, editedAlice);
 
-        // different job -> returns false
+        // different job -> returns true
         editedAlice = new PersonBuilder(ALICE).withJob(VALID_JOB_BOB).build();
         assertTrue(ALICE.equals(editedAlice));
 


### PR DESCRIPTION
The `Person::equals` method was using a different definition of equality check. This makes the code less maintainable.

By calling `Person::isSamePerson` in the `equals` method, we only have to maintain 1 definition for equality between `Person` objects.