### PR TITLE
Update Icon Variable Names based on Semantic Usage

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -58,11 +58,11 @@ public class PersonCard extends UiPart<Region> {
     }
     private void createFields() {
         name.setText(person.getName().fullName);
-        phone.setFields(PersonCardField.PHONE_ICON_LITERAL, person.getPhone().value);
-        address.setFields(PersonCardField.ADDRESS_ICON_LITERAL, person.getAddress().value);
-        email.setFields(PersonCardField.EMAIL_ICON_LITERAL, person.getEmail().value);
-        job.setFields(PersonCardField.JOB_ICON_LITERAL, person.getJob().value);
-        income.setFields(PersonCardField.INCOME_ICON_LITERAL, person.getIncome().toString());
+        phone.setFields(PersonCardField.ICON_LITERAL_PHONE, person.getPhone().value);
+        address.setFields(PersonCardField.ICON_LITERAL_ADDRESS, person.getAddress().value);
+        email.setFields(PersonCardField.ICON_LITERAL_EMAIL, person.getEmail().value);
+        job.setFields(PersonCardField.ICON_LITERAL_JOB, person.getJob().value);
+        income.setFields(PersonCardField.ICON_LITERAL_INCOME, person.getIncome().toString());
         remark.setText(person.getRemark().value);
         cardFields.getChildren().addAll(phone, address, email, job, income);
     }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -58,11 +58,11 @@ public class PersonCard extends UiPart<Region> {
     }
     private void createFields() {
         name.setText(person.getName().fullName);
-        phone.setFields("fas-phone-alt", person.getPhone().value);
-        address.setFields("fas-building", person.getAddress().value);
-        email.setFields("fas-envelope", person.getEmail().value);
-        job.setFields("fas-briefcase", person.getJob().value);
-        income.setFields("fas-dollar-sign", person.getIncome().toString());
+        phone.setFields(PersonCardField.PHONE_ICON_LITERAL, person.getPhone().value);
+        address.setFields(PersonCardField.ADDRESS_ICON_LITERAL, person.getAddress().value);
+        email.setFields(PersonCardField.EMAIL_ICON_LITERAL, person.getEmail().value);
+        job.setFields(PersonCardField.JOB_ICON_LITERAL, person.getJob().value);
+        income.setFields(PersonCardField.INCOME_ICON_LITERAL, person.getIncome().toString());
         remark.setText(person.getRemark().value);
         cardFields.getChildren().addAll(phone, address, email, job, income);
     }

--- a/src/main/java/seedu/address/ui/PersonCardField.java
+++ b/src/main/java/seedu/address/ui/PersonCardField.java
@@ -15,6 +15,12 @@ public class PersonCardField extends HBox {
     private FontIcon icon;
     private Label value;
 
+    public static final String PHONE_ICON_LITERAL = "fas-phone-alt";
+    public static final String ADDRESS_ICON_LITERAL = "fas-building";
+    public static final String EMAIL_ICON_LITERAL = "fas-envelope";
+    public static final String JOB_ICON_LITERAL = "fas-briefcase";
+    public static final String INCOME_ICON_LITERAL = "fas-dollar-sign";
+
     /**
      * Creates a template {@code PersonCardField} to display.
      */

--- a/src/main/java/seedu/address/ui/PersonCardField.java
+++ b/src/main/java/seedu/address/ui/PersonCardField.java
@@ -12,14 +12,14 @@ import javafx.scene.paint.Paint;
  * Represents a labelled field in the PersonCard
  */
 public class PersonCardField extends HBox {
+    public static final String ICON_LITERAL_PHONE = "fas-phone-alt";
+    public static final String ICON_LITERAL_ADDRESS = "fas-building";
+    public static final String ICON_LITERAL_EMAIL = "fas-envelope";
+    public static final String ICON_LITERAL_JOB = "fas-briefcase";
+    public static final String ICON_LITERAL_INCOME = "fas-dollar-sign";
+
     private FontIcon icon;
     private Label value;
-
-    public static final String PHONE_ICON_LITERAL = "fas-phone-alt";
-    public static final String ADDRESS_ICON_LITERAL = "fas-building";
-    public static final String EMAIL_ICON_LITERAL = "fas-envelope";
-    public static final String JOB_ICON_LITERAL = "fas-briefcase";
-    public static final String INCOME_ICON_LITERAL = "fas-dollar-sign";
 
     /**
      * Creates a template {@code PersonCardField} to display.


### PR DESCRIPTION
Icon variable names use the default names from the Icon Pack.

Developers are unable to easily tell what icons are present from the default names.

Lets update the Icon Variable names to reflect the Semantic Usage.

Closes #125 