### PR TITLE
Update ug to add known issue

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -754,6 +754,7 @@ Each status type is visually distinguished in the UI: Urgent is denoted by a red
 1. **When using multiple screens**, if you move the application to a secondary screen, and later switch to using only the primary screen, the GUI will open off-screen. The remedy is to delete the `preferences.json` file created by the application before running the application again.
 2. **If you minimize the Help Window** and then run the `help` command (or use the `Help` menu, or the keyboard shortcut `F1`) again, the original Help Window will remain minimized, and no new Help Window will appear. The remedy is to manually restore the minimized Help Window.
 3. **When inputting names that use `/`**, this can cause an `invalid command` error to be shown or even unintended attributes for the client added. Avoid using `/`, and spell out the names in full, for cases like 'Ramesh s/o Ravichandran', change it to 'Ramesh Son Of Ravichandran' 
+4.  **Using non-english text input can cause visual bugs**. This release fully supports English text input only**. Using non-English characters or text may cause display issues, including incorrect text direction and character rendering. We are actively working to expand international language support in future releases.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/model/client/Remark.java
+++ b/src/main/java/seedu/address/model/client/Remark.java
@@ -62,7 +62,7 @@ public class Remark {
         for (Remark currentRemark: remarks) {
             combinedValues.append(currentRemark.value + "\n");
         }
-        return new Remark(combinedValues.toString());
+        return new Remark(combinedValues.toString().trim());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -88,7 +88,7 @@ public class EditCommandTest {
 
         ClientBuilder clientInList = new ClientBuilder(lastClient);
         Client editedClient = clientInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTier(VALID_TIER_REJECT).withRemark(CommandCommons.DEFAULT_REMARK + "\nTest\n").build();
+                .withTier(VALID_TIER_REJECT).withRemark(CommandCommons.DEFAULT_REMARK + "\nTest").build();
 
         EditClientDescriptor descriptor = new EditClientDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTier(VALID_TIER_REJECT)


### PR DESCRIPTION
AgentAssist currently has buggy behaviour when using languages like Arabic, causing the Arabic text to be displayed in reverse.
However, this issue with usage of foreign languages, is not highlighted to users.

Adding the issue to `known issues`  will alert users to it and advise them to use English.

Closes #193.