### PR TITLE
Fix default remark showing up in UI

### DIFF
--- a/src/main/java/seedu/address/model/client/Remark.java
+++ b/src/main/java/seedu/address/model/client/Remark.java
@@ -4,12 +4,10 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.CommandCommons;
 
-
 /**
  * Represents a Client's remarks in the address book, as added by a user.
  * Guarantees: immutable;
  */
-
 public class Remark {
 
     public static final String MESSAGE_CONSTRAINTS = "Remark must contain only ASCII characters.";

--- a/src/main/java/seedu/address/ui/ClientCard.java
+++ b/src/main/java/seedu/address/ui/ClientCard.java
@@ -66,7 +66,7 @@ public class ClientCard extends UiPart<Region> {
         email.setFields(ClientCardField.ICON_LITERAL_EMAIL, client.getEmail().value);
         job.setFields(ClientCardField.ICON_LITERAL_JOB, client.getJob().value);
         income.setFields(ClientCardField.ICON_LITERAL_INCOME, client.getIncome().toString());
-        String clientRemark = client.getRemark().value.trim().toLowerCase();
+        String clientRemark = client.getRemark().value.trim();
         setRemarkField(clientRemark);
         cardFields.getChildren().addAll(phone, address, email, job, income, remark);
     }

--- a/src/main/java/seedu/address/ui/ClientCard.java
+++ b/src/main/java/seedu/address/ui/ClientCard.java
@@ -46,6 +46,7 @@ public class ClientCard extends UiPart<Region> {
     private FlowPane assignedStatus;
     @FXML
     private VBox cardFields;
+
     /**
      * Creates a {@code ClientCode} with the given {@code Client} and index to display.
      */
@@ -57,6 +58,7 @@ public class ClientCard extends UiPart<Region> {
         createStatus();
         createTier();
     }
+
     private void createFields() {
         name.setText(client.getName().fullName);
         phone.setFields(ClientCardField.ICON_LITERAL_PHONE, client.getPhone().value);
@@ -65,12 +67,16 @@ public class ClientCard extends UiPart<Region> {
         job.setFields(ClientCardField.ICON_LITERAL_JOB, client.getJob().value);
         income.setFields(ClientCardField.ICON_LITERAL_INCOME, client.getIncome().toString());
         String clientRemark = client.getRemark().value.trim().toLowerCase();
-        if (clientRemark.equalsIgnoreCase(CommandCommons.DEFAULT_REMARK)) {
+        setRemarkField(clientRemark);
+        cardFields.getChildren().addAll(phone, address, email, job, income, remark);
+    }
+
+    private void setRemarkField(String remarkText) {
+        if (remarkText.equalsIgnoreCase(CommandCommons.DEFAULT_REMARK)) {
             remark.setFields(ClientCardField.ICON_LITERAL_REMARK, "");
         } else {
-            remark.setFields(ClientCardField.ICON_LITERAL_REMARK, client.getRemark().value);
+            remark.setFields(ClientCardField.ICON_LITERAL_REMARK, remarkText);
         }
-        cardFields.getChildren().addAll(phone, address, email, job, income, remark);
     }
 
     private void createTier() {

--- a/src/main/java/seedu/address/ui/ClientDetailPanel.java
+++ b/src/main/java/seedu/address/ui/ClientDetailPanel.java
@@ -8,6 +8,7 @@ import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.CommandCommons;
 import seedu.address.model.client.Client;
 import seedu.address.model.status.Status;
 
@@ -128,7 +129,7 @@ public class ClientDetailPanel extends UiPart<Region> {
             setLabelText(incomeLabel, String.valueOf(client.getIncome()));
             setTier(client.getTier().getValue());
             setStatus(client.getStatus());
-            setLabelText(remarkLabel, client.getRemark().value);
+            setRemarkText(client.getRemark().value);
             tagsGroup.getChildren().clear();
             setTier(client.getTier().getValue());
             setStatus(client.getStatus());
@@ -148,6 +149,15 @@ public class ClientDetailPanel extends UiPart<Region> {
     private void setLabelText(Label label, String text) {
         if (label != null) {
             label.setText(text);
+        }
+    }
+
+    private void setRemarkText(String remarkText){
+        Label remarkLabel = new Label(remarkText);
+        if (remarkText.equalsIgnoreCase(CommandCommons.DEFAULT_REMARK)) {
+            setLabelText(remarkLabel, "");
+        } else {
+            setLabelText(remarkLabel, remarkText);
         }
     }
 

--- a/src/main/java/seedu/address/ui/ClientDetailPanel.java
+++ b/src/main/java/seedu/address/ui/ClientDetailPanel.java
@@ -152,7 +152,7 @@ public class ClientDetailPanel extends UiPart<Region> {
         }
     }
 
-    private void setRemarkText(String remarkText){
+    private void setRemarkText(String remarkText) {
         Label remarkLabel = new Label(remarkText);
         if (remarkText.equalsIgnoreCase(CommandCommons.DEFAULT_REMARK)) {
             setLabelText(remarkLabel, "");

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -89,7 +89,7 @@ public class EditCommandTest {
 
         ClientBuilder clientInList = new ClientBuilder(lastClient);
         Client editedClient = clientInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-                .withTier(VALID_TIER_REJECT).withRemark(CommandCommons.DEFAULT_REMARK + "\nTest").build();
+                .withTier(VALID_TIER_REJECT).withRemark("Test").build();
 
         EditClientDescriptor descriptor = new EditClientDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withTier(VALID_TIER_REJECT)


### PR DESCRIPTION
Add checks to both client card and client detailed panel view, to prevent values matching `na` (either lower or uppercase) from being shown to the user.