### PR TITLE
Fixing close command with trailing text doesn't work as advertised

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -17,6 +17,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
+import seedu.address.logic.commands.CloseCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -251,7 +252,7 @@ public class MainWindow extends UiPart<Stage> {
             reviewClientAfterEdit(indexToReview);
         } else if (commandResult.isShowClient()) {
             handleViewCommand(commandResult);
-        } else if (commandText.trim().toLowerCase().equals("close")) {
+        } else if (commandResult.getFeedbackToUser().equals(CloseCommand.MESSAGE_SUCCESS)) {
             handleCloseCommand();
         } else if (commandResult.isConfirmedDeletion() && currentlyViewedClient != null
                 && currentlyViewedClient.equals(commandResult.getDeletedClient())) {


### PR DESCRIPTION
closes #230 

The close command displays "Detailed view closed." in the results box even when
given with trailing text (e.g. "close abc"), but the detail panel remains open.
This behavior is inconsistent with the feedback shown to users.

This issue is considered a bug because:
- The command result indicates success ("Detailed view closed.") to users in the command result box
- The actual UI state differ from the claim above

Fix:
- Modified MainWindow.handlePostCommandExecution to trigger close action based
  on command result feedback

Tests still pass as command parsing logic remains unchanged.